### PR TITLE
resources section: set URL of read docs button to quickstart.md

### DIFF
--- a/src/scaffolding/master.scaffolding.hbs
+++ b/src/scaffolding/master.scaffolding.hbs
@@ -125,7 +125,7 @@
                 </bio-resource>
                 <bio-resource image-border-color="blue" data-resources="[{paths: ['components/BioResource/index.js']}]" imgsrc="_assets/documentation.svg">
                     <p>Read the Biotope documentation</p>
-                    <bio-button title="Read docs" modifier="blue" url="https://github.com/biotope/biotope/tree/master/docs"></bio-button>
+                    <bio-button title="Read docs" modifier="blue" url="https://github.com/biotope/biotope/blob/master/docs/quickstart.md"></bio-button>
                 </bio-resource>
             </div>
             <div class="col col--large-6">


### PR DESCRIPTION
set the URL of the second read docs button in the resources section to the same URL as the one in the splash screen section:

https://github.com/biotope/biotope/blob/master/docs/quickstart.md