### PR TITLE
feat(tracking): rework tracking optout

### DIFF
--- a/src/components/BioCookieBanner/BioCookieBanner.ts
+++ b/src/components/BioCookieBanner/BioCookieBanner.ts
@@ -15,7 +15,7 @@ class BioCookieBanner extends Component< BioCookieBannerProps, BioCookieBannerSt
 
     static dependencies = [
         BioButton as typeof Component
-    ]
+    ];
 
     public methods: BioCookieBannerMethods = {
 
@@ -40,7 +40,7 @@ class BioCookieBanner extends Component< BioCookieBannerProps, BioCookieBannerSt
     created() {
         super.created();
         this.classList.remove('hiddenOnLoad');
-        if (document.cookie.includes('cookie_consent')) {
+        if (document.cookie.indexOf("cookie_consent") != -1) {
             this.setState({
                 hidden: true
             })

--- a/src/components/BioCookieBanner/BioCookieBanner.ts
+++ b/src/components/BioCookieBanner/BioCookieBanner.ts
@@ -39,7 +39,8 @@ class BioCookieBanner extends Component< BioCookieBannerProps, BioCookieBannerSt
 
     created() {
         super.created();
-        if (document.cookie.includes('cookies-accepted=true')) {
+        this.classList.remove('hiddenOnLoad');
+        if (document.cookie.includes('cookie_consent')) {
             this.setState({
                 hidden: true
             })

--- a/src/components/BioGoogleTrackingStatus/BioGoogleTrackingStatus.ts
+++ b/src/components/BioGoogleTrackingStatus/BioGoogleTrackingStatus.ts
@@ -1,0 +1,64 @@
+import Component from "@biotope/element";
+import template from "./template";
+
+import {
+	BioGoogleTrackingStatusProps,
+	BioGoogleTrackingStatusState,
+	BioGoogleTrackingStatusMethods
+} from "./defines";
+
+class BioGoogleTrackingStatus extends Component<BioGoogleTrackingStatusProps, BioGoogleTrackingStatusState> {
+	static componentName = "bio-google-tracking-status";
+
+	static attributes = [];
+
+	public methods: BioGoogleTrackingStatusMethods = {};
+
+	created() {
+		super.created();
+
+        const cookies = document.cookie.split(';');
+        cookies.forEach((cookie: string) => {
+            if (cookie.includes('cookie_consent')) {
+                const d = cookie.split('=');
+                if (d[1] === 'true') {
+                    this.setState({
+                        status: 'active'
+                    })
+                } else {
+                    this.setState({
+                        status: 'inactive'
+                    })
+                }
+            }
+        })
+
+		this.addEventListener("google.tracking.disabled", () => {
+            this.setState({
+                status: 'inactive'
+            })
+        });
+        
+		this.addEventListener("google.tracking.enabled", () => {
+            this.setState({
+                status: 'active'
+            })
+        });
+	}
+
+	get defaultState() {
+		return {
+			status: "undecided"
+		};
+	}
+
+	get defaultProps() {
+		return {};
+	}
+
+	render() {
+		return template(this.html, { ...this.props, ...this.state, ...this.methods }, this.createStyle);
+	}
+}
+
+export default BioGoogleTrackingStatus;

--- a/src/components/BioGoogleTrackingStatus/BioGoogleTrackingStatus.ts
+++ b/src/components/BioGoogleTrackingStatus/BioGoogleTrackingStatus.ts
@@ -19,7 +19,7 @@ class BioGoogleTrackingStatus extends Component<BioGoogleTrackingStatusProps, Bi
 
         const cookies = document.cookie.split(';');
         cookies.forEach((cookie: string) => {
-            if (cookie.includes('cookie_consent')) {
+            if (cookie.indexOf("cookie_consent") != -1) {
                 const d = cookie.split('=');
                 if (d[1] === 'true') {
                     this.setState({
@@ -31,7 +31,7 @@ class BioGoogleTrackingStatus extends Component<BioGoogleTrackingStatusProps, Bi
                     })
                 }
             }
-        })
+        });
 
 		this.addEventListener("google.tracking.disabled", () => {
             this.setState({

--- a/src/components/BioGoogleTrackingStatus/defines.ts
+++ b/src/components/BioGoogleTrackingStatus/defines.ts
@@ -1,0 +1,22 @@
+/**
+ *  ## DEFINE ALL INTERFACES FOR BioGoogleTrackingStatus
+ **/
+
+/**
+ * Props
+ */
+interface BioGoogleTrackingStatusProps {}
+
+/**
+ * State
+ */
+interface BioGoogleTrackingStatusState {
+	status: string;
+}
+
+/**
+ * Methods
+ */
+interface BioGoogleTrackingStatusMethods {}
+
+export { BioGoogleTrackingStatusProps, BioGoogleTrackingStatusState, BioGoogleTrackingStatusMethods };

--- a/src/components/BioGoogleTrackingStatus/index.ts
+++ b/src/components/BioGoogleTrackingStatus/index.ts
@@ -1,0 +1,3 @@
+import BioGoogleTrackingStatus from './BioGoogleTrackingStatus';
+
+BioGoogleTrackingStatus.register();

--- a/src/components/BioGoogleTrackingStatus/styles.scss
+++ b/src/components/BioGoogleTrackingStatus/styles.scss
@@ -1,0 +1,16 @@
+@import "node_modules/@biotope/element/lib/host.mixin";
+@import "../../resources/scss/defaultSassImports.scss";
+
+@include host("bio-google-tracking-status") {
+	span {
+		&.inactive {
+			color: $bio-orange;
+		}
+		&.undecided {
+			color: $bio-dark-blue-gray;
+		}
+		&.active {
+			color: $bio-blue-green;
+		}
+	}
+}

--- a/src/components/BioGoogleTrackingStatus/template.ts
+++ b/src/components/BioGoogleTrackingStatus/template.ts
@@ -1,0 +1,16 @@
+import * as styles from './styles.scss';
+
+import { BioGoogleTrackingStatusProps, BioGoogleTrackingStatusState, BioGoogleTrackingStatusMethods } from './defines';
+
+
+export default (render: Function, data: BioGoogleTrackingStatusProps & BioGoogleTrackingStatusState & BioGoogleTrackingStatusMethods , createStyle: Function) => {
+    const labels = {
+        'active': 'Enabled',
+        'undecided': 'You haven\'t decided yet so tracking is disabled',
+        'inactive': 'Disabled' 
+    }
+    return render`
+        ${createStyle(styles)}
+        <div><strong>Google tracking status:</strong> <span class=${data.status}>${labels[data.status]}</span></div>
+    `;
+}

--- a/src/resources/scss/global.scss
+++ b/src/resources/scss/global.scss
@@ -492,3 +492,7 @@ bio-cookie-banner {
 	position: fixed;
 	bottom: 0;
 }
+
+.hiddenOnLoad {
+	display: none;
+}

--- a/src/resources/scss/settings/_settings.scss
+++ b/src/resources/scss/settings/_settings.scss
@@ -26,6 +26,7 @@ $bio-lighter-blue: #CED0DF;
 $bio-shadow-gray: #d3d3d3;
 $bio-blue-gray: #d4d9e2;
 $bio-lighter-blue-gray: #ecf4f9;
+$bio-blue-green: rgb(46, 162, 141);
 
 // BODY STYLES
 $body-bg: $bio-white;

--- a/src/resources/ts/main.ts
+++ b/src/resources/ts/main.ts
@@ -30,7 +30,7 @@ import ResourceLoader from "@biotope/resource-loader/lib/index.esm";
                     modal.dispatchEvent(new CustomEvent("modal.close"));
                 });
             }
-        });
+		});
     };
 
 	const setupResourceLoader = () => {

--- a/src/scaffolding/master.scaffolding.hbs
+++ b/src/scaffolding/master.scaffolding.hbs
@@ -411,7 +411,8 @@
                     for browsers at <a href="http://tools.google.com/dlpage/gaoptout?hl=de">http://tools.google.com/dlpage/gaoptout?hl=de</a>.</p>
                 <p>You can also prevent Google Universal Analytics from capturing your data by clicking the following link. Remove all tracking provided by this website by declining the use of 
                     Google Analytics:</p>
-                <p><a class="internal" data-cookie-settings>Open your cookie settings to decline being tracked using the Google Tag Manager and Google Analytics.</a></p>
+                <p><a class="internal" data-disable-google-tracking>Click here to disable Google tracking and reload the page.</a></p>
+                <bio-google-tracking-status data-resources="[{paths:['components/BioGoogleTrackingStatus/index.js']}]"></bio-google-tracking-status>
                 <p>We point out that this website uses Google Analytics with the extension "_anonymizeIp()". This means that IP addresses are stored 
                     exclusively in anonymous form, thus excluding any direct personal reference in connection with the stored data.</p>
                 <h4>8.	Google Tag Manager</h4>
@@ -419,8 +420,9 @@
                     tags. This means that no cookies are used and no personal data is collected. Google Tool Manager triggers other tags that may collect data. However, 
                     the Google Tag Manager does not access this data. If a deactivation has been made at the domain or cookie level, it remains valid for all tracking tags 
                     if they are implemented with the Google Tag Manager.</p>
-                <p><a class="internal" data-cookie-settings>
-                    Open your cookie settings to decline being tracked using the Google Tag Manager and Google Analytics.</a></p>
+                <p><a class="internal" data-disable-google-tracking>
+                    Click here to disable Google tracking and reload the page.</a></p>
+                <bio-google-tracking-status data-resources="[{paths:['components/BioGoogleTrackingStatus/index.js']}]"></bio-google-tracking-status>
                 <p>More information about the Google Tag Manager can be found here:</p>
                 <p><a href="http://www.google.de/tagmanager/faq.html">http://www.google.de/tagmanager/faq.html</a></p>
                 <p><a href="http://www.google.de/tagmanager/use-policy.html">http://www.google.de/tagmanager/use-policy.html</a></p>
@@ -437,8 +439,12 @@
                     <a href="https://www.linkedin.com/psettings/guest-controls/retargeting-opt-out">https://www.linkedin.com/psettings/guest-controls/retargeting-opt-out</a>
                     For more information on the LinkedIn Insight tag, please visit: <a href="https://www.linkedin.com/help/linkedin/answer/65521">https://www.linkedin.com/help/linkedin/answer/65521</a>
                     <p>
-                    <a data-cookie-settings class="internal">Open your cookie settings to decline being tracked using the LinkedIn Insight Tag.</a>
                     </p>
+                    </p>
+
+                    <p>
+                        <strong>Click on this link to be navigated to the website where you can opt out of LinkedIn tracking:</strong> 
+                        <a href="https://www.linkedin.com/psettings/guest-controls/retargeting-opt-out">https://www.linkedin.com/psettings/guest-controls/retargeting-opt-out</a>
                     </p>
                 <h4>10.	Your rights</h4>
                 <p>In particular, you may request information about the purposes of the processing, the category of personal data, the categories of recipients 
@@ -491,7 +497,7 @@
     </div>
 </bio-modal>
 
-<bio-cookie-banner data-resources="[{paths: ['components/BioCookieBanner/index.js']}]">
+<bio-cookie-banner data-resources="[{paths: ['components/BioCookieBanner/index.js']}]" class="hiddenOnLoad">
     <p>We use cookies to create the best possible website experience and see whether our marketing campaigns are effective. Google Analytics (cookies expire in 24 months)
         helps us gain a better understanding on how users interact with the website. With the LinkedIn Insight Tag (cookies expire in 24 months) we gain insights whether our
         marketing efforts are having the desired effect. You are free to decline these cookies, but we'd be happy if you let us use your anonymized data. Further information


### PR DESCRIPTION
before: tracking optout via re-opening of cookiebar -> decline.; now: google optout by clicking a
link that updates a label. linkedin optout with an external link.

#159