### PR TITLE
186 track as internal cta

### DIFF
--- a/src/components/BioButton/scaffolding/BioButton.hbs
+++ b/src/components/BioButton/scaffolding/BioButton.hbs
@@ -1,5 +1,5 @@
-<bio-button title="Watch" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
-<bio-button title="Watch" modifier="whiteText" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
-<bio-button title="Who's behind Biotope" modifier="long" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
-<bio-button title="Github" modifier="blue" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
-<bio-button title="Contact" modifier="full" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
+<bio-button title="Watch" data-resources="[{paths: ['components/BioButton/index.js']}]"></bio-button>
+<bio-button title="Watch" modifier="whiteText" data-resources="[{paths: ['components/BioButton/index.js']}]"></bio-button>
+<bio-button title="Who's behind Biotope" modifier="long" data-resources="[{paths: ['components/BioButton/index.js']}]"></bio-button>
+<bio-button title="Github" modifier="blue" data-resources="[{paths: ['components/BioButton/index.js']}]"></bio-button>
+<bio-button title="Contact" modifier="full" data-resources="[{paths: ['components/BioButton/index.js']}]"></bio-button>

--- a/src/components/BioLinkButton/scaffolding/BioLinkButton.hbs
+++ b/src/components/BioLinkButton/scaffolding/BioLinkButton.hbs
@@ -1,5 +1,5 @@
-<bio-link-button title="Watch" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
-<bio-link-button title="Watch" modifier="whiteText" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
-<bio-link-button title="Who's behind Biotope" modifier="long" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
-<bio-link-button title="Github" modifier="blue" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
-<bio-link-button title="Contact" modifier="full" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
+<bio-link-button title="Watch" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" href="https://www.biotope.sh"></bio-link-button>
+<bio-link-button title="Watch" modifier="whiteText" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" href="https://www.biotope.sh"></bio-link-button>
+<bio-link-button title="Who's behind Biotope" modifier="long" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" href="https://www.biotope.sh"></bio-link-button>
+<bio-link-button title="Github" modifier="blue" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" href="https://www.biotope.sh"></bio-link-button>
+<bio-link-button title="Contact" modifier="full" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" href="https://www.biotope.sh"></bio-link-button>

--- a/src/resources/ts/tracking.ts
+++ b/src/resources/ts/tracking.ts
@@ -96,7 +96,7 @@ initGoogleAnalytics();
 
 (window as any).biotope.initTrackingMethods = () => {
 	dataLayer = dataLayer || [];
-	const internalHostnames = ["localhost", "biotope.sh", "build.biotope.sh", "www.biotope.sh"];
+	const regexInternalHostnames = new RegExp('biotope.sh$|^localhost$', 'i');
 
 	const visitedSectionIds = [];
 	const visitSectionTime = 2000;
@@ -124,13 +124,13 @@ initGoogleAnalytics();
 	}
 
 	function trackLink(link: HTMLElement) {
-		const linkHref = link.getAttribute("href");
+		const linkHref = link.getAttribute('href');
 		const linkURL = new URL(linkHref);
-		const linkHostname = linkURL ? linkURL.hostname : "";
-		if (internalHostnames.indexOf(linkHostname) != -1) {
-			trackCallToAction("cta-intern", linkHref);
+		const linkHostname = linkURL ? linkURL.hostname : '';
+		if (regexInternalHostnames.test(linkHostname)) {
+			trackCallToAction('cta-intern', linkHref);
 		} else {
-			trackCallToAction("cta-extern", linkHref);
+			trackCallToAction('cta-extern', linkHref);
 		}
 	}
 


### PR DESCRIPTION
fixed tracking for internal links by using a regex to identify hostnames that end on "biotope.sh" or are "localhost" to identify all links correctly
also fixed scaffolding files for BioButton (removed url attribute) and BioLinkButton (renamed url attribute to href)