### PR TITLE
185 fix button border

### DIFF
--- a/src/components/BioButton/scaffolding/BioButton.hbs
+++ b/src/components/BioButton/scaffolding/BioButton.hbs
@@ -3,3 +3,7 @@
 <bio-button title="Who's behind Biotope" modifier="long" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
 <bio-button title="Github" modifier="blue" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
 <bio-button title="Contact" modifier="full" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
+<div style="background: #F17C61; padding: 10px; margin-top: 10px;">
+    <bio-button title="Accept" modifier="white" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
+    <bio-button title="Decline" modifier="white compact" data-resources="[{paths: ['components/BioButton/index.js']}]" url="https://www.biotope.sh"></bio-button>
+</div>

--- a/src/components/BioButton/styles.scss
+++ b/src/components/BioButton/styles.scss
@@ -26,8 +26,26 @@
 			color: $bio-white;
 		}
 
-        &.long {
+		&.long {
 			padding: 10px 15px;
+		}
+
+		&.white {
+			border: $border solid $bio-white;
+			color: $bio-white;
+			
+			&:hover{
+				background: $bio-white;
+				color: $bio-orange;
+			}
+		}
+		
+		&.compact {
+			min-width: 130px;
+			
+			@include breakpoint($medium){
+				min-width: 160px;
+			}
 		}
 	}
 }

--- a/src/components/BioLinkButton/scaffolding/BioLinkButton.hbs
+++ b/src/components/BioLinkButton/scaffolding/BioLinkButton.hbs
@@ -3,3 +3,6 @@
 <bio-link-button title="Who's behind Biotope" modifier="long" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
 <bio-link-button title="Github" modifier="blue" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
 <bio-link-button title="Contact" modifier="full" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" url="https://www.biotope.sh"></bio-link-button>
+<div style="background: #F17C61; padding: 10px; margin-top: 10px;">
+    <bio-link-button title="Read" modifier="white" data-resources="[{paths: ['components/BioLinkButton/index.js']}]" href="https://www.biotope.sh"></bio-link-button>
+</div>

--- a/src/components/BioLinkButton/styles.scss
+++ b/src/components/BioLinkButton/styles.scss
@@ -45,14 +45,6 @@
 			}
 		}
 
-		&.compact {
-			min-width: 130px;
-			
-			@include breakpoint($medium){
-				min-width: 160px;
-			}
-		}
-
 		&.whiteText{
 			color: $bio-white;
 		}


### PR DESCRIPTION
added missing classes "white" and "compact" to the BioButton styles to show the correct styling (white border, white text color, smaller width on smaller devices) in the cookie banner. Removed not used "compact" class from BioLinkButton because these have a fixed width of 160px and therefore the min-width in the compact class did not have any effect.
