### PR TITLE
189 add canonical tag

### DIFF
--- a/src/layouts/includes/htmlhead.meta.hbs
+++ b/src/layouts/includes/htmlhead.meta.hbs
@@ -20,3 +20,8 @@
 <!--DEV-NOTE: next two exntries are optional. define a custom share image and URL or remove this two lines -->
 <meta property="og:url" content="">
 <meta property="og:image" content="https://biotope.sh/_assets/biotope.png">
+
+{{#if canonical}}
+<!--DEV-NOTE: the canonical tag should be set wisely and for every page individually to not screw up SEO -->
+<link rel="canonical" href="{{canonical}}"/>
+{{/if}}

--- a/src/pages/01site.01master.hbs
+++ b/src/pages/01site.01master.hbs
@@ -12,4 +12,5 @@ description: Master page
 
 {{> layouts/layout.default
 	contentMain="scaffolding/master.scaffolding"
+	canonical="https://biotope.sh"
 }}


### PR DESCRIPTION
added a canonical tag by setting a corresponding variable in the page file. This is sensible because the canonical tag should be set for each page individually to avoid issues with SEO once we add more pages.